### PR TITLE
Changing some of the variables to be protected so the fixture can be extended.

### DIFF
--- a/src/main/java/smartrics/rest/fitnesse/fixture/RestFixture.java
+++ b/src/main/java/smartrics/rest/fitnesse/fixture/RestFixture.java
@@ -178,7 +178,7 @@ public class RestFixture extends ActionFixture {
 
     private static final Log LOG = LogFactory.getLog(RestFixture.class);
 
-    private Variables GLOBALS;
+    protected Variables GLOBALS;
 
     private RestResponse lastResponse;
 
@@ -212,7 +212,7 @@ public class RestFixture extends ActionFixture {
     private Url baseUrl;
 
     @SuppressWarnings("rawtypes")
-    private RowWrapper row;
+    protected RowWrapper row;
 
     private CellFormatter<?> formatter;
 


### PR DESCRIPTION
In the extended class, we wanted to run something before
the process row (preProcessRow) and to be able to implement new "set"
method that were similar to the setHeader method.  These methods are
all used to incorporate DBUnit into fitnesse.
