### PR TITLE
SlimFormatter now wraps everything in a DIV in order to deal with FitNesse now escaping everything that doesn't look like HTML by default

### DIFF
--- a/src/main/java/smartrics/rest/fitnesse/fixture/SlimFormatter.java
+++ b/src/main/java/smartrics/rest/fitnesse/fixture/SlimFormatter.java
@@ -55,7 +55,7 @@ public class SlimFormatter implements CellFormatter<String> {
 
     @Override
     public void exception(CellWrapper<String> cell, String exceptionMessage) {
-        cell.body("error:" + exceptionMessage);
+        cell.body("error:" + Tools.wrapInDiv(exceptionMessage));
     }
 
     @Override
@@ -64,7 +64,7 @@ public class SlimFormatter implements CellFormatter<String> {
         PrintStream ps = new PrintStream(out);
         exception.printStackTrace(ps);
         String m = Tools.toHtml(cell.getWrapped() + "\n-----\n") + Tools.toCode(Tools.toHtml(out.toString()));
-        cell.body("error:" + m);
+        cell.body("error:" + Tools.wrapInDiv(m));
     }
 
     @Override
@@ -94,22 +94,22 @@ public class SlimFormatter implements CellFormatter<String> {
     public void wrong(CellWrapper<String> expected, RestDataTypeAdapter ta) {
         String expectedContent = expected.body();
         expected.body(Tools.makeContentForWrongCell(expectedContent, ta, this, minLenForToggle));
-        expected.body("fail:" + expected.body());
+        expected.body("fail:" + Tools.wrapInDiv(expected.body()));
     }
 
     @Override
     public void right(CellWrapper<String> expected, RestDataTypeAdapter typeAdapter) {
-        expected.body("pass:" + Tools.makeContentForRightCell(expected.body(), typeAdapter, this, minLenForToggle));
+        expected.body("pass:" + Tools.wrapInDiv(Tools.makeContentForRightCell(expected.body(), typeAdapter, this, minLenForToggle)));
     }
 
     @Override
     public String gray(String string) {
-        return "report:" + Tools.toHtml(string);
+        return "report:" + Tools.wrapInDiv(Tools.toHtml(string));
     }
 
     @Override
     public void asLink(CellWrapper<String> cell, String link, String text) {
-        cell.body("report:" + Tools.toHtmlLink(link, text));
+        cell.body("report:" + Tools.wrapInDiv(Tools.toHtmlLink(link, text)));
     }
 
     @Override

--- a/src/main/java/smartrics/rest/fitnesse/fixture/support/Tools.java
+++ b/src/main/java/smartrics/rest/fitnesse/fixture/support/Tools.java
@@ -679,7 +679,7 @@ public final class Tools {
 		StringBuffer sb = new StringBuffer();
 		sb.append(toHtml(expected));
 		String actual = typeAdapter.toString();
-		if (formatter.isDisplayActual() && !expected.equals(actual)) {
+		if (formatter.isDisplayActual() && !expected.equals(actual)) {		  
 			sb.append(toHtml("\n"));
 			sb.append(formatter.label("expected"));
 			sb.append(toHtml("-----"));
@@ -713,5 +713,9 @@ public final class Tools {
 		}
 		return str;
 	}
+
+  public static String wrapInDiv(String body) {
+    return String.format("<div>%s</div>", body);
+  }
 
 }

--- a/src/test/java/smartrics/rest/fitnesse/fixture/SlimFormatterTest.java
+++ b/src/test/java/smartrics/rest/fitnesse/fixture/SlimFormatterTest.java
@@ -42,7 +42,7 @@ public class SlimFormatterTest {
         StringTypeAdapter actual = new StringTypeAdapter();
         actual.set("2");
         formatter.check(c, actual);
-        assertThat(c.body(), is(equalTo("report:2")));
+        assertThat(c.body(), is(equalTo("report:<div>2</div>")));
     }
 
     @Test
@@ -63,7 +63,7 @@ public class SlimFormatterTest {
         StringTypeAdapter actual = new StringTypeAdapter();
         actual.set("abc123");
         formatter.check(c, actual);
-        assertThat(c.body(), is(equalTo("pass:abc123")));
+        assertThat(c.body(), is(equalTo("pass:<div>abc123</div>")));
     }
 
     @Test
@@ -87,7 +87,7 @@ public class SlimFormatterTest {
 
         assertThat(
                 c.body(),
-                is(equalTo("pass:something&nbsp;matching&nbsp;logically&nbsp;abc123<br/><i><span class='fit_label'>expected</span></i><hr/><br/>abc123<br/><i><span class='fit_label'>actual</span></i>")));
+                is(equalTo("pass:<div>something&nbsp;matching&nbsp;logically&nbsp;abc123<br/><i><span class='fit_label'>expected</span></i><hr/><br/>abc123<br/><i><span class='fit_label'>actual</span></i></div>")));
     }
 
     @Test
@@ -98,7 +98,7 @@ public class SlimFormatterTest {
         StringTypeAdapter actual = new StringTypeAdapter();
         actual.set("def345");
         formatter.check(c, actual);
-        assertThat(c.body(), is(equalTo("fail:abc123")));
+        assertThat(c.body(), is(equalTo("fail:<div>abc123</div>")));
     }
 
     @Test
@@ -110,7 +110,7 @@ public class SlimFormatterTest {
         actual.set("def345");
         formatter.check(c, actual);
 
-        assertThat(c.body(), is(equalTo("fail:abc123<br/><i><span class='fit_label'>expected</span></i><hr/><br/>def345<br/><i><span class='fit_label'>actual</span></i>")));
+        assertThat(c.body(), is(equalTo("fail:<div>abc123<br/><i><span class='fit_label'>expected</span></i><hr/><br/>def345<br/><i><span class='fit_label'>actual</span></i></div>")));
     }
 
     @Test
@@ -121,7 +121,7 @@ public class SlimFormatterTest {
         TextBodyTypeAdapter actual = new TextBodyTypeAdapter();
         actual.set("<xml />");
         formatter.check(c, actual);
-        assertThat(c.body(), is(equalTo(Tools.toHtml("pass:<xml />"))));
+        assertThat(c.body(), is(equalTo("pass:<div>" + Tools.toHtml("<xml />") + "</div>")));
     }
 
     @Test
@@ -129,7 +129,7 @@ public class SlimFormatterTest {
         SlimFormatter formatter = new SlimFormatter();
         SlimCell c = new SlimCell("abc123");
         formatter.asLink(c, "http://localhost", "text");
-        assertThat(c.body(), is(equalTo("report:<a href='http://localhost'>text</a>")));
+        assertThat(c.body(), is(equalTo("report:<div><a href='http://localhost'>text</a></div>")));
     }
 
     @Test


### PR DESCRIPTION
Since version 20130530, FitNesse has started escaping fixture output by default. We recently upgraded to 20130530, and were confronted with the fact that the RestFixture output was nog longer nicely rendered HTML, with links etc., but a bunch of escaped HTML that resulted in a distinctly "view source" experience. Other people had this problem with other fixtures, which is why the FitNesse project accepted unclebob/fitnesse#274. This causes FitNesse to not escape fixture output if it **looks like** HTML. In practice, this means that the output has to start with an HTML tag in order for FitNesse to not escape it. Several of the cells in the RestFixture output contained HTML, but did not start with a tag, and were therefore escaped by FitNesse. This pull request modifies the SlimFormatter so that all cell content is wrapped in a DIV, and thus will never be escaped by FitNesse.
