### PR TITLE
Removed out-of-date 'TODO'

### DIFF
--- a/src/main/java/smartrics/rest/fitnesse/fixture/support/SlimVariables.java
+++ b/src/main/java/smartrics/rest/fitnesse/fixture/support/SlimVariables.java
@@ -29,7 +29,7 @@ import fitnesse.slim.StatementExecutorInterface;
  */
 public class SlimVariables extends Variables {
 
-	private final StatementExecutorInterface executor; // TODO use it!!!
+	private final StatementExecutorInterface executor;
 
 	/**
 	 * initialises the variables. reade


### PR DESCRIPTION
Remove out-of-date 'TODO' not to induce into error future maintainers.