### PR TITLE
Enable both variable substitutions and URL encodings in GET calls

### DIFF
--- a/src/main/java/smartrics/rest/fitnesse/fixture/support/Variables.java
+++ b/src/main/java/smartrics/rest/fitnesse/fixture/support/Variables.java
@@ -38,7 +38,10 @@ public abstract class Variables {
 	 * pattern matching a variable name: {@code \%([a-zA-Z0-9_]+)\%}
 	 */
 	public static Pattern SPECIAL_REGEX_CHARS = Pattern.compile("[{}()\\[\\].+*?^$\\\\|]");
-	public static final Pattern VARIABLES_PATTERN = Pattern.compile("\\%([a-zA-Z0-9_]+)\\%");
+	// exclude 0-9, A-F from the first variable name as those are confused with URL encodings.
+	public static final Pattern VARIABLES_PATTERN = Pattern.compile("\\%([a-zG-Z_][a-zA-Z0-9_]*)\\%");
+	// original regex pattern, allowing all initial characters.
+	//	public static final Pattern VARIABLES_PATTERN = Pattern.compile("\\%([a-zA-Z0-9_]+)\\%");
 	private static final String FIT_NULL_VALUE = fitSymbolForNull();
 	private String nullValue = "null";
 

--- a/src/test/java/smartrics/rest/fitnesse/fixture/RestFixtureTest.java
+++ b/src/test/java/smartrics/rest/fitnesse/fixture/RestFixtureTest.java
@@ -122,7 +122,19 @@ public class RestFixtureTest {
         verify(row.getCell(1)).body("name is one");
         verify(mockCellFormatter).right(isA(CellWrapper.class), isA(StringTypeAdapter.class));
     }
-    
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void setBodyShouldNotRenderEncodedSymbols() {
+        Fixture.setSymbol("name", "one");
+        RowWrapper<?> row = helper.createTestRow("setBody", "this %name% is encoded %7B%22myvar%22%7D");
+        when(mockCellFormatter.fromRaw("this %name% is encoded %7B%22myvar%22%7D")).thenReturn("this %name% is encoded " +
+          "%7B%22myvar%22%7D");
+        fixture.processRow(row);
+        verify(row.getCell(1)).body("this one is encoded %7B%22myvar%22%7D");
+        verify(mockCellFormatter).right(isA(CellWrapper.class), isA(StringTypeAdapter.class));
+    }
+
     @Test
     public void mustSetConfigNameToDefaultWhenNotSpecifiedAsSecondOptionalParameter_SLIM() {
         fixture = new RestFixture(BASE_URL, "configName");

--- a/src/test/java/smartrics/rest/fitnesse/fixture/support/VariablesTest.java
+++ b/src/test/java/smartrics/rest/fitnesse/fixture/support/VariablesTest.java
@@ -54,6 +54,17 @@ public class VariablesTest {
     }
 
     @Test
+    public void variablesAreSubstitutedWithCurrentValueWhenHexLabelsAreIdentifiedWithinPercentSymbol(){
+        Variables v1 = new FitVariables();
+        v1.put("AHexPrefix", "100");
+        v1.put("aNonHexPrefix", "200");
+        String hexText = v1.substitute("the current value of AHexPrefix is %AHexPrefix%.");
+        assertEquals("the current value of AHexPrefix is %AHexPrefix%.", hexText);
+        String nonHexText = v1.substitute("the current value of aNonHexPrefix is %aNonHexPrefix%.");
+        assertEquals("the current value of aNonHexPrefix is 200.", nonHexText);
+    }
+
+    @Test
     public void substitutingSymbolsContainingRegexSpecialCharsShouldWorkAsExpected_issue118(){
         Variables v1 = new FitVariables();
         v1.put("ID", "${ABC}");


### PR DESCRIPTION
When we attempted to use Smartrics/RestFixture with URL encoded json GET parameters, the %varName% variable substitution interpreted URL encoded json punctuation as the start of a variable. For example, the json string {"myBool":"true", "myDouble":0.3} becomes %7B%22myBool%22%3A%22true%22%2C%20%22myDouble%22%3A0.3%7D as a URL encoded parameter in the GET string.

The RestFixture variable parser looks for the variable name '7B', and fails as '7B' is not defined by a LET statement.  

We solved this issue by excluding any HEX number as a leading %varName% variable name character.  HEX numbers start with 0-9A-F.  Lowercase a-f work fine, as URL encodings are upper case.  All existing RestFixture test cases work as-is. That is, all JUnit example variable substitutions use non-HEX leading characters.  This PR also contains unit tests to illustrate the limited substitution. 

Others who use capital letters A-F may find their tests break. We may want to activate this feature through a feature flag setting, although we did not add the feature flag in the PR.
