### PR TITLE
JS optimisation limit. Fixes #74

### DIFF
--- a/src/main/java/smartrics/rest/fitnesse/fixture/RestFixture.java
+++ b/src/main/java/smartrics/rest/fitnesse/fixture/RestFixture.java
@@ -971,7 +971,7 @@ public class RestFixture implements StatementExecutorConsumer, RunnerVariablesPr
 					"Missing string to evaluate)");
 			return;
 		}
-		JavascriptWrapper wrapper = new JavascriptWrapper(this);
+		JavascriptWrapper wrapper = new JavascriptWrapper(this, config);
 		Object result = null;
 		try {
 			result = wrapper.evaluateExpression(lastResponse, jsCell.body());

--- a/src/main/java/smartrics/rest/fitnesse/fixture/support/JSONBodyTypeAdapter.java
+++ b/src/main/java/smartrics/rest/fitnesse/fixture/support/JSONBodyTypeAdapter.java
@@ -43,7 +43,7 @@ public class JSONBodyTypeAdapter extends XPathBodyTypeAdapter {
      * @param config            the config
      */
     public JSONBodyTypeAdapter(RunnerVariablesProvider variablesProvider, Config config) {
-        wrapper = new JavascriptWrapper(variablesProvider);
+        wrapper = new JavascriptWrapper(variablesProvider, config);
         imports = config.getAsMap("restfixture.javascript.imports.map", new HashMap<String, String>());
     }
 

--- a/src/main/java/smartrics/rest/fitnesse/fixture/support/JavascriptWrapper.java
+++ b/src/main/java/smartrics/rest/fitnesse/fixture/support/JavascriptWrapper.java
@@ -20,18 +20,28 @@
  */
 package smartrics.rest.fitnesse.fixture.support;
 
-import org.mozilla.javascript.*;
-import smartrics.rest.client.RestData.Header;
-import smartrics.rest.client.RestResponse;
-import smartrics.rest.fitnesse.fixture.RunnerVariablesProvider;
-
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.EcmaError;
+import org.mozilla.javascript.EvaluatorException;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
+
+import smartrics.rest.client.RestData.Header;
+import smartrics.rest.client.RestResponse;
+import smartrics.rest.fitnesse.fixture.RunnerVariablesProvider;
 
 /**
  * Wrapper class to all that related to JavaScript.
@@ -52,7 +62,7 @@ public class JavascriptWrapper {
      * the name of the JS object containing the json body: {@code jsonbody}.
      */
     public static final String JSON_OBJ_NAME = "jsonbody";
-    private static final long _64K = 65534;
+	private static final long _32K = 32768;
     private RunnerVariablesProvider variablesProvider;
 
     public JavascriptWrapper(RunnerVariablesProvider variablesProvider) {
@@ -101,7 +111,7 @@ public class JavascriptWrapper {
             return null;
         }
         Context context = Context.enter();
-        removeOptimisationForLargeExpressions(json, expression, context);
+		removeOptimisationForLargeExpressions(json, expression, context);
         ScriptableObject scope = context.initStandardObjects();
         injectImports(context, scope, imports);
         injectFitNesseSymbolMap(scope);
@@ -192,7 +202,7 @@ public class JavascriptWrapper {
     }
 
     private void removeOptimisationForLargeExpressions(String responseBody, String expression, Context context) {
-        if ((responseBody != null && responseBody.getBytes().length > _64K) || expression.getBytes().length > _64K) {
+		if ((responseBody != null && responseBody.getBytes().length > _32K) || expression.getBytes().length > _32K) {
             context.setOptimizationLevel(-1);
         }
     }

--- a/src/main/java/smartrics/rest/fitnesse/fixture/support/JavascriptWrapper.java
+++ b/src/main/java/smartrics/rest/fitnesse/fixture/support/JavascriptWrapper.java
@@ -20,28 +20,18 @@
  */
 package smartrics.rest.fitnesse.fixture.support;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import org.mozilla.javascript.*;
+import smartrics.rest.client.RestData.Header;
+import smartrics.rest.client.RestResponse;
+import smartrics.rest.fitnesse.fixture.RunnerVariablesProvider;
+
+import java.io.*;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import org.mozilla.javascript.Context;
-import org.mozilla.javascript.EcmaError;
-import org.mozilla.javascript.EvaluatorException;
-import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
-
-import smartrics.rest.client.RestData.Header;
-import smartrics.rest.client.RestResponse;
-import smartrics.rest.fitnesse.fixture.RunnerVariablesProvider;
 
 /**
  * Wrapper class to all that related to JavaScript.
@@ -62,11 +52,13 @@ public class JavascriptWrapper {
      * the name of the JS object containing the json body: {@code jsonbody}.
      */
     public static final String JSON_OBJ_NAME = "jsonbody";
-	private static final long _32K = 32768;
+	private static final long _64K = 65535;
     private RunnerVariablesProvider variablesProvider;
+    private Config config;
 
-    public JavascriptWrapper(RunnerVariablesProvider variablesProvider) {
+    public JavascriptWrapper(RunnerVariablesProvider variablesProvider, Config config) {
         this.variablesProvider = variablesProvider;
+        this.config = config;
     }
 
     /**
@@ -202,7 +194,8 @@ public class JavascriptWrapper {
     }
 
     private void removeOptimisationForLargeExpressions(String responseBody, String expression, Context context) {
-		if ((responseBody != null && responseBody.getBytes().length > _32K) || expression.getBytes().length > _32K) {
+        final Long thresholdLimit = config.getAsLong("restfixture.response.optimisation.threshold", _64K);
+		if ((responseBody != null && responseBody.getBytes().length > thresholdLimit) || expression.getBytes().length > thresholdLimit) {
             context.setOptimizationLevel(-1);
         }
     }

--- a/src/main/java/smartrics/rest/fitnesse/fixture/support/LetBodyJsHandler.java
+++ b/src/main/java/smartrics/rest/fitnesse/fixture/support/LetBodyJsHandler.java
@@ -20,14 +20,11 @@
  */
 package smartrics.rest.fitnesse.fixture.support;
 
-import org.slf4j.Logger;
-import smartrics.rest.client.RestResponse;
-import smartrics.rest.fitnesse.fixture.RunnerVariablesProvider;
-
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.slf4j.LoggerFactory.getLogger;
+import smartrics.rest.client.RestResponse;
+import smartrics.rest.fitnesse.fixture.RunnerVariablesProvider;
 
 /**
  * Handles let expressions on XML content, returning XML string rather than the
@@ -37,11 +34,9 @@ import static org.slf4j.LoggerFactory.getLogger;
  */
 public class LetBodyJsHandler implements LetHandler {
 
-    private static final Logger LOG = getLogger(LetBodyJsHandler.class);
-
     @Override
     public String handle(RunnerVariablesProvider variablesProvider, Config config, RestResponse response, Object expressionContext, String expression) {
-        JavascriptWrapper js = new JavascriptWrapper(variablesProvider);
+        JavascriptWrapper js = new JavascriptWrapper(variablesProvider, config);
         final Map<String, String> urlMap = config.getAsMap("restfixture.javascript.imports.map", new HashMap<String, String>());
         Object result = js.evaluateExpression(response, expression, urlMap);
         if (result == null) {

--- a/src/main/java/smartrics/rest/fitnesse/fixture/support/LetBodyPlainHandler.java
+++ b/src/main/java/smartrics/rest/fitnesse/fixture/support/LetBodyPlainHandler.java
@@ -32,7 +32,7 @@ public class LetBodyPlainHandler implements LetHandler {
 
 
     @Override
-    public String handle(RunnerVariablesProvider variablesProvider, Config cOnfig, RestResponse response, Object expressionContext, String expression) {
+    public String handle(RunnerVariablesProvider variablesProvider, Config config, RestResponse response, Object expressionContext, String expression) {
         return response.getBody();
     }
 

--- a/src/test/java/smartrics/rest/fitnesse/fixture/support/JavascriptWrapperTest.java
+++ b/src/test/java/smartrics/rest/fitnesse/fixture/support/JavascriptWrapperTest.java
@@ -20,17 +20,14 @@
  */
 package smartrics.rest.fitnesse.fixture.support;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
-
 import org.junit.Before;
 import org.junit.Test;
-
 import smartrics.rest.client.RestResponse;
 import smartrics.rest.fitnesse.fixture.RunnerVariablesProvider;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 /**
  * Test class for the js body handler.
@@ -40,7 +37,10 @@ import smartrics.rest.fitnesse.fixture.RunnerVariablesProvider;
  */
 public class JavascriptWrapperTest {
 
+    private static final String CONFIG_NAME = "configName";
     private FitVariables variables;
+    private Config config;
+
     private final RunnerVariablesProvider variablesProvider = new RunnerVariablesProvider() {
 		@Override
 		public Variables createRunnerVariables() {
@@ -52,13 +52,14 @@ public class JavascriptWrapperTest {
     public void setUp() {
         variables = new FitVariables();
         variables.clearAll();
+        config = Config.getConfig();
     }
 
     @Test
     public void shouldProvideSymbolMapInJsContext() {
         variables.put("my_sym", "98");
         RestResponse response = new RestResponse();
-        JavascriptWrapper h = new JavascriptWrapper(variablesProvider);
+        JavascriptWrapper h = new JavascriptWrapper(variablesProvider, config);
         Object res = h.evaluateExpression(response, "'my sym is: ' + symbols.get('my_sym')");
         assertThat(res.toString(), is(equalTo("my sym is: 98")));
     }
@@ -66,7 +67,7 @@ public class JavascriptWrapperTest {
     @Test
     public void shouldProvideLastResponseBodyInJsContext() {
         RestResponse response = createResponse();
-        JavascriptWrapper h = new JavascriptWrapper(variablesProvider);
+        JavascriptWrapper h = new JavascriptWrapper(variablesProvider, config);
         Object res = h.evaluateExpression(response, "'my last response body is: ' + response.body");
         assertThat(res.toString(), is(equalTo("my last response body is: <xml />")));
     }
@@ -75,7 +76,7 @@ public class JavascriptWrapperTest {
     public void shouldProvideLastResponseBodyAsJsonForJsonContentTypeInJsContext() {
         String json = "{ \"person\" : { \"name\" : \"Rokko\", \"age\" : \"30\" } }";
         RestResponse response = createResponse(ContentType.JSON, json);
-        JavascriptWrapper h = new JavascriptWrapper(variablesProvider);
+        JavascriptWrapper h = new JavascriptWrapper(variablesProvider, config);
         Object res = h.evaluateExpression(response, "'My friend ' + response.jsonbody.person.name + ' is ' + response.jsonbody.person.age + ' years old.'");
         assertThat(res.toString(), is(equalTo("My friend Rokko is 30 years old.")));
     }
@@ -84,7 +85,7 @@ public class JavascriptWrapperTest {
     public void shouldProvideLastResponseBodyAsJsonForContentThatLooksLikeJsonInJsContext() {
         String json = "{ \"person\" : { \"name\" : \"Rokko\", \"age\" : \"30\" } }";
         RestResponse response = createResponse(ContentType.TEXT, json);
-        JavascriptWrapper h = new JavascriptWrapper(variablesProvider);
+        JavascriptWrapper h = new JavascriptWrapper(variablesProvider, config);
         Object res = h.evaluateExpression(response, "'My friend ' + response.jsonbody.person.name + ' is ' + response.jsonbody.person.age + ' years old.'");
         assertThat(res.toString(), is(equalTo("My friend Rokko is 30 years old.")));
     }
@@ -98,28 +99,28 @@ public class JavascriptWrapperTest {
         }
         sb.append("\"}");
         RestResponse response = createResponse(ContentType.JSON, sb.toString());
-        JavascriptWrapper h = new JavascriptWrapper(variablesProvider);
+        JavascriptWrapper h = new JavascriptWrapper(variablesProvider, config);
         Object res = h.evaluateExpression(response, "response.jsonbody.content.length");
         assertThat(res.toString(), is(equalTo(Integer.toString(size))));
     }
 
     @Test
     public void shouldNotProvideLastResponseBodyInJsContextIfResponseIsNull() {
-        JavascriptWrapper h = new JavascriptWrapper(variablesProvider);
+        JavascriptWrapper h = new JavascriptWrapper(variablesProvider, config);
         Object res = h.evaluateExpression((RestResponse) null, "'response is null: ' + (response == null)");
         assertThat(res.toString(), is(equalTo("response is null: true")));
     }
 
     @Test
     public void shouldHandleNullReturnedByJsEvaluation() {
-        JavascriptWrapper h = new JavascriptWrapper(variablesProvider);
+        JavascriptWrapper h = new JavascriptWrapper(variablesProvider, config);
         Object res = h.evaluateExpression((RestResponse) null, "null");
         assertThat(res, is(nullValue()));
     }
 
     @Test
     public void shouldHandleNullReturnedByStringJsEvaluation() {
-        JavascriptWrapper h = new JavascriptWrapper(variablesProvider);
+        JavascriptWrapper h = new JavascriptWrapper(variablesProvider, config);
         Object res = h.evaluateExpression((String) null, "null");
         assertThat(res, is(nullValue()));
     }
@@ -127,7 +128,7 @@ public class JavascriptWrapperTest {
     @Test
     public void shouldProvideLastResponseResourceInJsContext() {
         RestResponse response = createResponse();
-        JavascriptWrapper h = new JavascriptWrapper(variablesProvider);
+        JavascriptWrapper h = new JavascriptWrapper(variablesProvider, config);
         Object res = h.evaluateExpression(response, "'my last response resource is: ' + response.resource");
         assertThat(res.toString(), is(equalTo("my last response resource is: /resources")));
     }
@@ -135,7 +136,7 @@ public class JavascriptWrapperTest {
     @Test
     public void shouldProvideLastResponseStatusTextInJsContext() {
         RestResponse response = createResponse();
-        JavascriptWrapper h = new JavascriptWrapper(variablesProvider);
+        JavascriptWrapper h = new JavascriptWrapper(variablesProvider, config);
         Object res = h.evaluateExpression(response, "'my last response statusText is: ' + response.statusText");
         assertThat(res.toString(), is(equalTo("my last response statusText is: OK")));
     }
@@ -143,7 +144,7 @@ public class JavascriptWrapperTest {
     @Test
     public void shouldProvideLastResponseTxIdInJsContext() {
         RestResponse response = createResponse();
-        JavascriptWrapper h = new JavascriptWrapper(variablesProvider);
+        JavascriptWrapper h = new JavascriptWrapper(variablesProvider, config);
         Object res = h.evaluateExpression(response, "'my last response transactionId is: ' + response.transactionId");
         assertThat(res.toString(), is(equalTo("my last response transactionId is: 123456789")));
     }
@@ -151,7 +152,7 @@ public class JavascriptWrapperTest {
     @Test
     public void shouldProvideLastResponseStatusCodeInJsContext() {
         RestResponse response = createResponse();
-        JavascriptWrapper h = new JavascriptWrapper(variablesProvider);
+        JavascriptWrapper h = new JavascriptWrapper(variablesProvider, config);
         Object res = h.evaluateExpression(response, "'my last response statusCode is: ' + response.statusCode");
         assertThat(res.toString(), is(equalTo("my last response statusCode is: 200")));
     }
@@ -159,7 +160,7 @@ public class JavascriptWrapperTest {
     @Test
     public void shouldProvideLastResponseHeadersInJsContext() {
         RestResponse response = createResponse();
-        JavascriptWrapper h = new JavascriptWrapper(variablesProvider);
+        JavascriptWrapper h = new JavascriptWrapper(variablesProvider, config);
 
         Object res = h.evaluateExpression(response, "'my last response Content-Type is: ' + response.header('Content-Type')");
         assertThat(res.toString(), is(equalTo("my last response Content-Type is: application/xml")));
@@ -186,7 +187,7 @@ public class JavascriptWrapperTest {
     @Test
     public void shouldTrapJavascriptErrorAndWrapThemInErrors() throws Exception {
         RestResponse response = createResponse();
-        JavascriptWrapper h = new JavascriptWrapper(variablesProvider);
+        JavascriptWrapper h = new JavascriptWrapper(variablesProvider, config);
         try {
             h.evaluateExpression(response, "some erroneous javascript");
             fail("Must throw a Javascript Exception");


### PR DESCRIPTION
@smartrics even after the fix for #74 in 4.3, We're still seeing the JS limit exception
```bash
Caused by: smartrics.rest.fitnesse.fixture.support.JavascriptException: Encountered code generation error while compiling script: generated bytecode for method exceeds 64K limit. (unnamed script#1)
    at smartrics.rest.fitnesse.fixture.support.JavascriptWrapper.evaluateExpression(JavascriptWrapper.java:137)
    at smartrics.rest.fitnesse.fixture.support.JavascriptWrapper.injectJson(JavascriptWrapper.java:128)
    at smartrics.rest.fitnesse.fixture.support.JavascriptWrapper.evaluateExpression(JavascriptWrapper.java:108)
    at smartrics.rest.fitnesse.fixture.support.JSONBodyTypeAdapter.eval(JSONBodyTypeAdapter.java:56)
    at smartrics.rest.fitnesse.fixture.support.XPathBodyTypeAdapter.equals(XPathBodyTypeAdapter.java:71)
```

The only way I could get it working was by halving the check limit? Do you think is that reasonable?