### PR TITLE
Delete the unused methods and tests for supporting scenario

### DIFF
--- a/src/main/java/smartrics/rest/fitnesse/fixture/RestFixture.java
+++ b/src/main/java/smartrics/rest/fitnesse/fixture/RestFixture.java
@@ -640,19 +640,6 @@ public class RestFixture implements StatementExecutorConsumer, RunnerVariablesPr
 	}
 
 	/**
-	 * \@sglebs - fixes #162. necessary to work with a scenario
-     * @param body the body to set
-     * @return the body after substitution
-	 */
-	@SuppressWarnings({ "rawtypes", "unchecked" })
-	public String setBody(String body) {
-		requestBody = body;
-		if (GLOBALS != null)
-			requestBody = GLOBALS.substitute(body);
-		return requestBody;
-	}
-
-	/**
 	 * <code>| setHeader | http headers go here as nvp |</code>
 	 * <p>
 	 * header text must be nvp. name and value must be separated by ':' and each
@@ -689,24 +676,6 @@ public class RestFixture implements StatementExecutorConsumer, RunnerVariablesPr
         return requestHeaders;
     }
 
-	/**
-	 * \@sglebs - fixes #161. necessary to work with a scenario
-     * @param headers the headers string to set
-     * @return the headers map
-	 */
-    public Map<String, String> setHeader(String headers) {
-        requestHeaders = new LinkedHashMap<String, String>();
-        return addHeader(headers);
-    }
-
-	/**
-	 * \@sglebs - fixes #161. necessary to work with a scenario
-     * @param headers the headers string to set
-     * @return the headers map
-	 */
-	public Map<String, String>  setHeaders(String headers) {
-		return setHeader(headers);
-	}
 
 	/**
 	 * Equivalent to setHeader - syntactic sugar to indicate that you can now.

--- a/src/test/java/smartrics/rest/fitnesse/fixture/RestFixtureTest.java
+++ b/src/test/java/smartrics/rest/fitnesse/fixture/RestFixtureTest.java
@@ -1180,28 +1180,6 @@ public class RestFixtureTest {
         }
     }
 
-    @Test
-    public void setsRequestBodyExplicitly() {
-        RestFixture f = new RestFixture("http://localhost:9090");
-        f.setBody("<body />");
-        assertThat(f.getRequestBody(), is("<body />"));
-    }
-
-    @Test
-    public void setsRequestBodyExplicitlyWithSubstitutions() {
-        RowWrapper<?> row = helper.createTestRow("let", "foo", "const", "bar", "");
-        fixture.processRow(row);
-        fixture.setBody("<%foo% />");
-        assertThat(fixture.getRequestBody(), is("<bar />"));
-    }
-
-    @Test
-    public void addHeaderExplicitly() {
-        Map<String, String> map = fixture.addHeader("header1:one");
-        fixture.addHeader("header2:two");
-        assertThat(map.get("header1"), is("one"));
-        assertThat(map.get("header2"), is("two"));
-    }
 
     @Test
     public void addHeaderExplicitlyWithSubstitutions() {
@@ -1211,12 +1189,6 @@ public class RestFixtureTest {
         assertThat(map.get("header1"), is("bar"));
     }
 
-    @Test
-    public void setHeaderExplicitly() {
-        fixture.setHeader("header1:one");
-        Map<String, String> map = fixture.setHeader("header1:two");
-        assertThat(map.get("header1"), is("two"));
-    }
 
     @Test
     public void setBaseUrlExplicitly() {


### PR DESCRIPTION
Delete the unused methods and tests for supporting scenario, these methods are implemented in the RestFixtureExtensions project.

I have created another class inherited from the class RestFixture to support the use of scenario syntax, that class inherits many powerful functions of class RestFixture, including assertion when making request and retains the RestFixture syntax, it is more easier and seamless to use with RestFixture and scenario syntax, that class has some functions whose signatures conflict with that of methods used for supporting scenario in class RestFixture, I checked those methods are not used in RestFixtureExtensions project, and I want to open source the classes(https://github.com/jinlxz/RestFixtureScenario) I created for supporting scenario syntax, thus I hope those methods can be removed.

Thanks.